### PR TITLE
fix: deepcopy not working on older neovim versions

### DIFF
--- a/lua/render-markdown/state.lua
+++ b/lua/render-markdown/state.lua
@@ -94,7 +94,7 @@ function M.default_buffer_config()
         link = config.link,
         sign = config.sign,
         win_options = config.win_options,
-    }, true)
+    })
 end
 
 ---@return string[]


### PR DESCRIPTION
`vim.deepcopy` function doesn't have the second argument on older neovim versions (0.9.5) and thus the plugin is not working on them. The simplest fix is to simply remove the second argument, sacrificing a minimal performance gain for wider support. From the testing that I did on my side, the plugin works normally with this change