### PR TITLE
fix: heading borders with indentation

### DIFF
--- a/lua/render-markdown/core/node_info.lua
+++ b/lua/render-markdown/core/node_info.lua
@@ -58,7 +58,12 @@ function NodeInfo:level()
     local parent = self.node:parent()
     while parent ~= nil and parent:type() ~= 'document' do
         if parent:type() == 'section' then
-            level = level + 1
+            local child = parent:child(0)
+            child = child and child:child(0)
+            local is_first_heading = child and child:type() == 'atx_h1_marker'
+            if not is_first_heading then
+                level = level + 1
+            end
         end
         parent = parent:parent()
     end

--- a/lua/render-markdown/handler/markdown.lua
+++ b/lua/render-markdown/handler/markdown.lua
@@ -69,21 +69,9 @@ function Handler:section(info)
         return
     end
 
-    local start_row = info.start_row
-    local heading_renderer = self.renderers.heading --[[@as render.md.render.Heading?]]
-    -- If heading borders are on, and we reuse an empty line in the buffer for the top border, that line needs to be
-    -- indented as well
-    if
-        self.config.heading.border
-        and heading_renderer
-        and heading_renderer:has_space_for_border('above', info, self.context.last_heading)
-    then
-        start_row = start_row - 1
-    end
-
     -- Each level stacks inline marks so we do not need to multiply spaces
     -- However skipping a level, i.e. 2 -> 5, will only add one level of spaces
-    for row = start_row, info.end_row - 1 do
+    for row = info.start_row, info.end_row - 1 do
         self.marks:add(false, row, 0, {
             priority = 0,
             virt_text = { { str.spaces(indent.per_level), 'Normal' } },

--- a/lua/render-markdown/handler/markdown.lua
+++ b/lua/render-markdown/handler/markdown.lua
@@ -69,9 +69,21 @@ function Handler:section(info)
         return
     end
 
+    local start_row = info.start_row
+    local heading_renderer = self.renderers.heading --[[@as render.md.render.Heading?]]
+    -- If heading borders are on, and we reuse an empty line in the buffer for the top border, that line needs to be
+    -- indented as well
+    if
+        self.config.heading.border
+        and heading_renderer
+        and heading_renderer:has_space_for_border('above', info, self.context.last_heading)
+    then
+        start_row = start_row - 1
+    end
+
     -- Each level stacks inline marks so we do not need to multiply spaces
     -- However skipping a level, i.e. 2 -> 5, will only add one level of spaces
-    for row = info.start_row, info.end_row - 1 do
+    for row = start_row, info.end_row - 1 do
         self.marks:add(false, row, 0, {
             priority = 0,
             virt_text = { { str.spaces(indent.per_level), 'Normal' } },

--- a/lua/render-markdown/render/base.lua
+++ b/lua/render-markdown/render/base.lua
@@ -41,13 +41,14 @@ end
 
 ---@protected
 ---@param line { [1]: string, [2]: string }[]
+---@param level integer?
 ---@return { [1]: string, [2]: string }[]
-function Base:indent_virt_line(line)
+function Base:indent_virt_line(line, level)
     local indent = self.config.indent
     if not indent.enabled then
         return line
     end
-    local level = self.info:level()
+    level = level or self.info:level()
     if level <= 0 then
         return line
     end

--- a/lua/render-markdown/render/base.lua
+++ b/lua/render-markdown/render/base.lua
@@ -47,7 +47,7 @@ function Base:indent_virt_line(line)
     if not indent.enabled then
         return line
     end
-    local level = self.info:level() - 1
+    local level = self.info:level()
     if level <= 0 then
         return line
     end

--- a/lua/render-markdown/render/heading.lua
+++ b/lua/render-markdown/render/heading.lua
@@ -72,18 +72,6 @@ function Render:render()
     self:conceal_underline()
 end
 
----@param position 'above'|'below'
----@param info render.md.NodeInfo
----@param last_heading integer
----@return boolean
-function Render:has_space_for_border(position, info, last_heading)
-    if position == 'above' then
-        return str.width(info:line('above')) == 0 and info.start_row - 1 ~= last_heading
-    else
-        return str.width(self.info:line('below')) == 0
-    end
-end
-
 ---@private
 ---@return integer
 function Render:icon()
@@ -186,7 +174,10 @@ function Render:border(width)
         { self.heading.above:rep(prefix), self.data.foreground },
         { self.heading.above:rep(width - self.heading.left_pad - prefix), background },
     }
-    if self:has_space_for_border('above', self.info, self.context.last_heading) then
+    if str.width(self.info:line('above')) == 0 and self.info.start_row - 1 ~= self.context.last_heading then
+        if self.data.level > 1 then
+            line_above = self:indent_virt_line(line_above, 1)
+        end
         self.marks:add(true, self.info.start_row - 1, 0, {
             virt_text = line_above,
             virt_text_pos = 'overlay',
@@ -203,7 +194,7 @@ function Render:border(width)
         { self.heading.below:rep(prefix), self.data.foreground },
         { self.heading.below:rep(width - self.heading.left_pad - prefix), background },
     }
-    if self:has_space_for_border('below', self.info, self.context.last_heading) then
+    if str.width(self.info:line('below')) == 0 then
         self.marks:add(true, self.info.end_row + 1, 0, {
             virt_text = line_below,
             virt_text_pos = 'overlay',

--- a/lua/render-markdown/render/heading.lua
+++ b/lua/render-markdown/render/heading.lua
@@ -72,6 +72,18 @@ function Render:render()
     self:conceal_underline()
 end
 
+---@param position 'above'|'below'
+---@param info render.md.NodeInfo
+---@param last_heading integer
+---@return boolean
+function Render:has_space_for_border(position, info, last_heading)
+    if position == 'above' then
+        return str.width(info:line('above')) == 0 and info.start_row - 1 ~= last_heading
+    else
+        return str.width(self.info:line('below')) == 0
+    end
+end
+
 ---@private
 ---@return integer
 function Render:icon()
@@ -174,7 +186,7 @@ function Render:border(width)
         { self.heading.above:rep(prefix), self.data.foreground },
         { self.heading.above:rep(width - self.heading.left_pad - prefix), background },
     }
-    if str.width(self.info:line('above')) == 0 and self.info.start_row - 1 ~= self.context.last_heading then
+    if self:has_space_for_border('above', self.info, self.context.last_heading) then
         self.marks:add(true, self.info.start_row - 1, 0, {
             virt_text = line_above,
             virt_text_pos = 'overlay',
@@ -191,7 +203,7 @@ function Render:border(width)
         { self.heading.below:rep(prefix), self.data.foreground },
         { self.heading.below:rep(width - self.heading.left_pad - prefix), background },
     }
-    if str.width(self.info:line('below')) == 0 then
+    if self:has_space_for_border('below', self.info, self.context.last_heading) then
         self.marks:add(true, self.info.end_row + 1, 0, {
             virt_text = line_below,
             virt_text_pos = 'overlay',


### PR DESCRIPTION
2 fixes for some small bugs with heading borders and indentation.

I made 2 separate commits, I can split this up into 2 PRs if you want to.

## 1 heading borders when there is no first heading
When calculating the indentation for virtual lines, the code assumed that there is always a first level heading. If there isn't, the indentation is off by 1.

| Before fix | After fix |
| -  | - |
|![20240911_19h17m39s_grim](https://github.com/user-attachments/assets/4641cda0-87ba-48a2-8fe7-94c2be164394) | ![20240911_19h25m07s_grim](https://github.com/user-attachments/assets/9e07e6ea-84de-4085-8e90-9272f4eb1733) |

```md
No first level

## Second level

Foo bar

| foo | bar |
| --- | --- |
```


## 2 heading border with indentation
If an empty line is reused to render the top border of a heading, that line is not indented together with the rest of the headline and section.

| Before fix | After fix |
| - | - |
| ![20240911_19h28m21s_grim](https://github.com/user-attachments/assets/fb8b688e-8d76-4cb5-9ccb-11170e918d92) | ![20240911_19h28m32s_grim](https://github.com/user-attachments/assets/ce885b5d-4620-4b2a-bf56-ac22b664c9ca) |

```md
# First level

Foo bar

## Second level

```

Using `self.renderers.heading` is maybe a bit ugly here. I wanted to abstract the `has_space_for_border` logic somewhere, there might be a better way to do this.