### PR TITLE
fix: not updating when window scrolled

### DIFF
--- a/lua/render-markdown/manager.lua
+++ b/lua/render-markdown/manager.lua
@@ -52,7 +52,7 @@ function M.attach(buf)
         return
     end
     local config = state.get(buf)
-    local events = { 'BufWinEnter', 'BufLeave', 'CursorHold', 'CursorMoved' }
+    local events = { 'BufWinEnter', 'BufLeave', 'CursorHold', 'CursorMoved', 'WinScrolled' }
     local change_events = { 'DiffUpdated', 'ModeChanged', 'TextChanged' }
     if config:render('i') then
         vim.list_extend(events, { 'CursorHoldI', 'CursorMovedI' })


### PR DESCRIPTION
The rendering is not updated when the window is scrolled while the cursor is fixed (can be reproduces using `<C-y>`, `<C-e>`, `zz`, `zt`, `zb` to scroll the window). This leaves new elements that becomes visible in current window undecorated.

To fix this simply add 'WinScrolled' event to the updating events.