### PR TITLE
fix: ensure nil checks before Neovim API calls

### DIFF
--- a/lua/render-markdown/core/util.lua
+++ b/lua/render-markdown/core/util.lua
@@ -32,10 +32,10 @@ end
 ---@param win integer
 ---@return boolean
 function M.valid(buf, win)
-    if not vim.api.nvim_buf_is_valid(buf) then
+    if buf == nil or not vim.api.nvim_buf_is_valid(buf) then
         return false
     end
-    if not vim.api.nvim_win_is_valid(win) then
+    if win == nil or not vim.api.nvim_win_is_valid(win) then
         return false
     end
     return buf == vim.fn.winbufnr(win)


### PR DESCRIPTION
fix an issue where closing a window occasionally triggers an error due to an invalid window reference:

```
Error detected while processing BufLeave Autocommands for "<buffer=2>":
Error executing lua callback: ...y/render-markdown.nvim/lua/render-markdown/core/util.lua:38: Invalid 'window': Expected Lua number
stack traceback:
        [C]: in function 'nvim_win_is_valid'
        ...y/render-markdown.nvim/lua/render-markdown/core/util.lua:38: in function 'valid'
        ...azy/render-markdown.nvim/lua/render-markdown/core/ui.lua:80: in function 'update'
        ...azy/render-markdown.nvim/lua/render-markdown/manager.lua:77: in function <...azy/render-markdown.nvim/lua/render-markdown/manager.lua:70>
```
