### PR TITLE
fix(coq): use last char before cursor instead of last on line

### DIFF
--- a/lua/render-markdown/integ/coq.lua
+++ b/lua/render-markdown/integ/coq.lua
@@ -22,7 +22,7 @@ local function complete(args, callback)
         if not source.enabled() then
             return nil
         end
-        local character = args.line:sub(#args.line, #args.line)
+        local character = args.line:sub(args.pos[2], args.pos[2])
         if not vim.tbl_contains(source.trigger_characters(), character) then
             return nil
         end


### PR DESCRIPTION
I saw the notification of my PR being merged and noticed that I had made a small mistake. It should be solved now.