### PR TITLE
Checkbox list completion improvements

### DIFF
--- a/lua/render-markdown/integ/source.lua
+++ b/lua/render-markdown/integ/source.lua
@@ -70,12 +70,11 @@ function M.items(buf, row, col)
         end
     elseif node:type() == 'list_item' or vim.tbl_contains(list_markers, node:type()) then
         local last_marker = M.list_prefix(row, node)
-        print(last_marker)
         local checkbox = config.checkbox
         table.insert(items, M.item(last_marker .. '[ ] ', checkbox.unchecked.icon, 'unchecked'))
         table.insert(items, M.item(last_marker .. '[x] ', checkbox.checked.icon, 'checked'))
         for name, component in pairs(checkbox.custom) do
-            table.insert(items, M.item(component.raw, component.rendered, name))
+            table.insert(items, M.item(list_prefix .. component.raw .. ' ', component.rendered, name))
         end
     end
     return items

--- a/lua/render-markdown/integ/source.lua
+++ b/lua/render-markdown/integ/source.lua
@@ -26,9 +26,8 @@ function M.list_prefix(row, node)
         return '' -- Don't run if on the same line, entry should already have a list marker.
     end
 
-    local start_row = select(1, marker:range())
     -- Retrieve the line from the buffer
-    local marker_line = vim.api.nvim_buf_get_lines(0, start_row, start_row + 1, false)[1]
+    local marker_line = vim.api.nvim_buf_get_lines(0, marker_row, marker_row + 1, false)[1]
 
     if not marker_line or #marker_line == 0 then
         return '' -- Return empty if the line is empty or doesn't exist

--- a/lua/render-markdown/integ/source.lua
+++ b/lua/render-markdown/integ/source.lua
@@ -11,6 +11,37 @@ local list_markers = {
 ---@class render.md.Source
 local M = {}
 
+---@private
+---@param row integer
+---@param node TSNode
+---@return string
+function M.list_prefix(row, node)
+    local marker = node:named_child(0)
+    if not marker then
+        return ''
+    end
+
+    local marker_row = marker:range()
+    if marker_row == row then
+        return '' -- Don't run if on the same line, entry should already have a list marker.
+    end
+
+    local start_row = select(1, marker:range())
+    -- Retrieve the line from the buffer
+    local marker_line = vim.api.nvim_buf_get_lines(0, start_row, start_row + 1, false)[1]
+
+    if not marker_line or #marker_line == 0 then
+        return '' -- Return empty if the line is empty or doesn't exist
+    end
+
+    -- Define valid list markers
+    local valid_markers = { ['-'] = true, ['+'] = true, ['*'] = true }
+    local first_char = marker_line:match('%S')
+
+    -- Return corresponding marker if valid, otherwise default to empty string
+    return valid_markers[first_char] and first_char .. ' ' or ''
+end
+
 ---@return boolean
 function M.enabled()
     return manager.is_attached(util.current('buf'))
@@ -38,9 +69,11 @@ function M.items(buf, row, col)
             table.insert(items, M.item(component.raw, component.rendered, nil))
         end
     elseif node:type() == 'list_item' or vim.tbl_contains(list_markers, node:type()) then
+        local last_marker = M.list_prefix(row, node)
+        print(last_marker)
         local checkbox = config.checkbox
-        table.insert(items, M.item('[ ]', checkbox.unchecked.icon, 'unchecked'))
-        table.insert(items, M.item('[x]', checkbox.checked.icon, 'checked'))
+        table.insert(items, M.item(last_marker .. '[ ] ', checkbox.unchecked.icon, 'unchecked'))
+        table.insert(items, M.item(last_marker .. '[x] ', checkbox.checked.icon, 'checked'))
         for name, component in pairs(checkbox.custom) do
             table.insert(items, M.item(component.raw, component.rendered, name))
         end

--- a/lua/render-markdown/integ/source.lua
+++ b/lua/render-markdown/integ/source.lua
@@ -69,10 +69,10 @@ function M.items(buf, row, col)
             table.insert(items, M.item(component.raw, component.rendered, nil))
         end
     elseif node:type() == 'list_item' or vim.tbl_contains(list_markers, node:type()) then
-        local last_marker = M.list_prefix(row, node)
+        local list_prefix = M.list_prefix(row, node)
         local checkbox = config.checkbox
-        table.insert(items, M.item(last_marker .. '[ ] ', checkbox.unchecked.icon, 'unchecked'))
-        table.insert(items, M.item(last_marker .. '[x] ', checkbox.checked.icon, 'checked'))
+        table.insert(items, M.item(list_prefix .. '[ ] ', checkbox.unchecked.icon, 'unchecked'))
+        table.insert(items, M.item(list_prefix .. '[x] ', checkbox.checked.icon, 'checked'))
         for name, component in pairs(checkbox.custom) do
             table.insert(items, M.item(list_prefix .. component.raw .. ' ', component.rendered, name))
         end


### PR DESCRIPTION
I worked on the auto completion for the check boxes and added 2 changes. 

1. The default checkbox text (both checked and unchecked) can now be customized using a new 'raw' field. This update has been reflected in the README. The change was implemented to provide greater flexibility for formatting, depending on the user's setup. For instance, users previously had to manually add a space every time I created a checkbox but now it can be added as the auto-complete text.

        checked = {
            -- Replaces '[x]' of 'task_list_marker_checked'
            raw = '[ ]', -- Optionnal parameter. This can be used to replace variations of the checkbox such as with spaces ('[ ] ',  ' [ ], etc.) or with one of the list char. (- [ ], + [ ] , * [ ])
            icon = '󰱒 ',
            -- Highlight for the checked icon
            highlight = 'RenderMarkdownChecked',
            -- Highlight for item associated with checked checkbox
            scope_highlight = nil,
        },

2. The second change has a bit more impact.
When the autocomplete checks for the checkbox, it now verifies whether the first non-whitespace character is a list marker ('-', '+', or "*"). Without this check, the autocomplete would insert [ ] or [x], which wouldn't render correctly as a checkbox.

If a marker is detected, the autocomplete will exclude it from its available options.

Without dash present : 
![image](https://github.com/user-attachments/assets/446c1ba7-8f8b-4135-9b2d-f9fc8b371fa6)

With dash present : 
![image](https://github.com/user-attachments/assets/35740ab1-4965-4640-ba93-4cacc11cc7ad)


