### PR TITLE
fix(health): update to not require nvim-treesitter

### DIFF
--- a/lua/render-markdown/health.lua
+++ b/lua/render-markdown/health.lua
@@ -21,22 +21,15 @@ function M.check()
         vim.health.error(message)
     end
 
+    M.start('treesitter')
+    M.check_parser('markdown')
+    M.check_parser('markdown_inline')
+
     local latex = state.get(0).latex
     local latex_advice = 'Disable LaTeX support to avoid this warning by setting { latex = { enabled = false } }'
 
-    M.start('nvim-treesitter')
-    local has_treesitter = pcall(require, 'nvim-treesitter')
-    if has_treesitter then
-        vim.health.ok('installed')
-        for _, language in ipairs({ 'markdown', 'markdown_inline' }) do
-            M.check_parser(language)
-            M.check_highlight(language)
-        end
-        if latex.enabled then
-            M.check_parser('latex', latex_advice)
-        end
-    else
-        vim.health.error('not installed')
+    if latex.enabled then
+        M.check_parser('latex', latex_advice)
     end
 
     M.start('icons')
@@ -88,24 +81,14 @@ end
 ---@param language string
 ---@param advice? string
 function M.check_parser(language, advice)
-    local parsers = require('nvim-treesitter.parsers')
-    if parsers.has_parser(language) then
+    local has_parser, _ = pcall(vim.treesitter.get_parser, 0, language, { error = false })
+
+    if has_parser then
         vim.health.ok(language .. ': parser installed')
     elseif advice == nil then
         vim.health.error(language .. ': parser not installed')
     else
         vim.health.warn(language .. ': parser not installed', advice)
-    end
-end
-
----@private
----@param language string
-function M.check_highlight(language)
-    local configs = require('nvim-treesitter.configs')
-    if configs.is_enabled('highlight', language, 0) then
-        vim.health.ok(language .. ': highlight enabled')
-    else
-        vim.health.error(language .. ': highlight not enabled')
     end
 end
 

--- a/lua/render-markdown/health.lua
+++ b/lua/render-markdown/health.lua
@@ -32,6 +32,8 @@ function M.check()
         M.check_parser('latex', latex_advice)
     end
 
+    M.check_highlight('markdown')
+
     M.start('icons')
     local provider = Icons.provider()
     if provider ~= nil then
@@ -89,6 +91,29 @@ function M.check_parser(language, advice)
         vim.health.error(language .. ': parser not installed')
     else
         vim.health.warn(language .. ': parser not installed', advice)
+    end
+end
+
+---@private
+---@param language string
+function M.check_highlight(language)
+    --
+    -- As the markdown parser is part of Neovim, and nvim-treesitter no longer provides
+    -- .is_enabled() for the main branch, create a markdown buffer and check the state.
+    --
+    -- See: https://github.com/MeanderingProgrammer/render-markdown.nvim/pull/322#discussion_r1947393569
+    local bufnr = vim.api.nvim_create_buf(false, true)
+
+    vim.bo[bufnr].filetype = language
+
+    local has_highlighter = vim.treesitter.highlighter.active[bufnr] ~= nil
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+
+    if has_highlighter then
+        vim.health.ok(language .. ': highlight enabled')
+    else
+        vim.health.error(language .. ': highlight not enabled')
     end
 end
 


### PR DESCRIPTION
`nvim-treesitter` on the `main` (dev) brain no longer has a `.has_parser()` call.

This migrates to use the built in `vim.treesitter` module.

I removed the highlights check since it is redundant now.