### PR TITLE
Callback when the buffer is cleared

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ require('render-markdown').setup({
         attach = function() end,
         -- Called after plugin renders a buffer
         render = function() end,
+        -- Called after plugin clears a buffer
+        clear = function() end,
     },
     heading = {
         -- Turn on / off heading icon & background rendering

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -37,8 +37,11 @@ in this plugin. Different plugins will have different setups, below are some exa
             latex = { enabled = false },
             win_options = { conceallevel = { rendered = 2 } },
             on = {
-                attach = function()
+                render = function()
                     require('nabla').enable_virt({ autogen = true })
+                end,
+                clear = function()
+                    require('nabla').disable_virt()
                 end,
             },
         },

--- a/doc/render-markdown.txt
+++ b/doc/render-markdown.txt
@@ -321,6 +321,9 @@ Default Configuration ~
             attach = function() end,
             -- Called after plugin renders a buffer
             render = function() end,
+            -- Called after plugin clears a buffer
+            clear = function() end,
+
         },
         heading = {
             -- Turn on / off heading icon & background rendering

--- a/lua/render-markdown/core/ui.lua
+++ b/lua/render-markdown/core/ui.lua
@@ -152,6 +152,7 @@ function M.run_update(buf, win, change)
         state.on.render({ buf = buf })
     else
         M.clear(buf, buffer_state)
+        state.on.clear({ buf = buf })
     end
 end
 

--- a/lua/render-markdown/init.lua
+++ b/lua/render-markdown/init.lua
@@ -21,6 +21,7 @@ local M = {}
 ---@class (exact) render.md.UserCallback
 ---@field public attach? fun(ctx: render.md.CallbackContext)
 ---@field public render? fun(ctx: render.md.CallbackContext)
+---@field public clear? fun(ctx: render.md.CallbackContext)
 
 ---@class (exact) render.md.UserInjection
 ---@field public enabled? boolean
@@ -401,6 +402,8 @@ M.default_config = {
         attach = function() end,
         -- Called after plugin renders a buffer
         render = function() end,
+        -- Called after plugin clears a buffer
+        clear = function() end,
     },
     heading = {
         -- Turn on / off heading icon & background rendering

--- a/lua/render-markdown/state.lua
+++ b/lua/render-markdown/state.lua
@@ -335,7 +335,7 @@ function M.validate()
                 :check()
         end)
         :nested('on', function(on)
-            on:type({ 'attach', 'render' }, 'function'):check()
+            on:type({ 'attach', 'render' , 'clear'}, 'function'):check()
         end)
         :nested('overrides', function(overrides)
             overrides

--- a/lua/render-markdown/types.lua
+++ b/lua/render-markdown/types.lua
@@ -3,6 +3,7 @@
 ---@class (exact) render.md.Callback
 ---@field public attach fun(ctx: render.md.CallbackContext)
 ---@field public render fun(ctx: render.md.CallbackContext)
+---@field public clear fun(ctx: render.md.CallbackContext)
 
 ---@class (exact) render.md.Injection
 ---@field public enabled boolean


### PR DESCRIPTION
When using `nabla.nvim` to render latex formulas and entering one of the modes not present in `render_modes`, some parts of the formulas (those that extend in the lines above or below) are still rendered. 

Using this callback, it is possible to fully disable the rendering latex formulas using `require('nabla').disable_virt()`. 
I've updated the part of the documentation relative to nabla integration to show this use case.