### PR TITLE
feat: allow rendering footnotes without superscript

### DIFF
--- a/lua/render-markdown/render/shortcut.lua
+++ b/lua/render-markdown/render/shortcut.lua
@@ -161,13 +161,17 @@ function Render:footnote(text)
     end
 
     local footnote = self.link.footnote
-    if not footnote.superscript then
-        return
-    end
 
-    local value = Converter.to_superscript(footnote.prefix .. text .. footnote.suffix)
-    if value == nil then
-        return
+    local value = ''
+
+    if footnote.superscript then
+        local converted_value = Converter.to_superscript(footnote.prefix .. text .. footnote.suffix)
+        if converted_value == nil then
+            return nil
+        end
+        value = converted_value
+    else
+        value = footnote.prefix .. text .. footnote.suffix
     end
 
     self.marks:add_over('link', self.node, {


### PR DESCRIPTION
When footnote rendering is enabled, the superscript can look a little ugly if a monospace font is in use. This allows rendering a footnote using the full, normal-size font even if the superscript option is turned off, rather than disabling rendering of footnotes entirely if the superscript option is disabled.