### PR TITLE
use user input to filter completion results

### DIFF
--- a/lua/render-markdown/command.lua
+++ b/lua/render-markdown/command.lua
@@ -9,16 +9,30 @@ M.name = 'RenderMarkdown'
 ---@private
 M.plugin = 'render-markdown.nvim'
 
+local starts_with = function(str, start)
+    return str:sub(1, #start) == start
+end
+
+local get_matching_values = function(value, potential_values)
+    local matching_values = {}
+    for _, potential_value in ipairs(potential_values) do
+        if starts_with(potential_value, value) then
+            table.insert(matching_values, potential_value)
+        end
+    end
+    return matching_values
+end
+
 ---Should only be called from plugin directory
 function M.setup()
     vim.api.nvim_create_user_command(M.name, M.command, {
         nargs = '*',
         desc = M.plugin .. ' commands',
-        complete = function(_, cmdline)
+        complete = function(ArgLead, cmdline)
             if cmdline:find(M.name .. '%s+%S+%s+.*') then
                 return {}
             elseif cmdline:find(M.name .. '%s+') then
-                return vim.tbl_keys(api)
+                return get_matching_values(ArgLead, vim.tbl_keys(api))
             else
                 return {}
             end


### PR DESCRIPTION
Hi, 

I've been enjoying using the plugin! 

I've been using the `RenderMarkdown toggle` command recently, start with typing `tog`, and always get all the completion results with `<Tab>`. Then having to do a bunch of <C-n> to get to the right one.

This will do a partial match based on the user input and show results that start with the input. Leaving an empty input will still show all results like before.

For example `buf` then `<Tab>` will get `buf_enable`, `buf_disable`, `buf_toggle`.