### PR TITLE
fix: get correct list of ft and cmd from lazy function

### DIFF
--- a/lua/render-markdown/lib/env.lua
+++ b/lua/render-markdown/lib/env.lua
@@ -10,8 +10,9 @@ function M.lazy(key)
     if type(package.loaded.lazy) ~= 'table' then
         return {}
     end
-    local ok, lazy_config = pcall(require, 'lazy.core.config')
-    if not ok then
+    local config_ok, lazy_config = pcall(require, 'lazy.core.config')
+    local plugin_ok, lazy_plugin = pcall(require, 'lazy.core.plugin')
+    if not config_ok or not plugin_ok then
         return {}
     end
     local name = 'render-markdown.nvim'
@@ -19,14 +20,8 @@ function M.lazy(key)
     if not plugin then
         return {}
     end
-    local values = plugin[key]
-    if type(values) == 'table' then
-        return values
-    elseif type(values) == 'string' then
-        return { values }
-    else
-        return {}
-    end
+
+    return lazy_plugin.values(plugin, key, true)
 end
 
 ---@param file string|integer


### PR DESCRIPTION
The current approach of getting the `ft` and `cmd` values from `lazy.nvim` only consider the last spec definition of the `lazy.nvim` configuration.

If the plugin spec is defined in 2 places it will create metatables and it will just get the `ft` defined in the last definition.

Example:

Spec definition run first:

```lua
  {
    'MeanderingProgrammer/render-markdown.nvim',
    dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' },
    ft = { 'markdown', 'norg', 'rmd', 'org', 'codecompanion' },
    opts = {
      file_types = { 'markdown', 'norg', 'rmd', 'org', 'codecompanion' },
      completions = {
        blink = {
          enabled = true,
        },
      },
    },
  },

```
Second spec definition somewhere else in your config, ran last:

```lua
  {
    'MeanderingProgrammer/render-markdown.nvim',
    ft = { 'Avante' },
    opts = {
      file_types = { 'Avante' },
    },
    opts_extend = {
      'file_types',
    },
  },
```

This creates a structure like this after inspecing the plugin in the Lazy UI:

```
  dependencies = { "nvim-treesitter", "nvim-web-devicons" },
  dir = "/Users/carlos.calla/.local/share/nvim/lazy/render-markdown.nvim",
  lazy = true,
  name = "render-markdown.nvim",
  url = "https://github.com/MeanderingProgrammer/render-markdown.nvim.git",
  <metatable> = {
    __index = { "MeanderingProgrammer/render-markdown.nvim",
      ft = { "Avante" },
      opts = {
        file_types = { "Avante" }
      },  
      opts_extend = { "file_types" },
      <metatable> = {
        __index = { "MeanderingProgrammer/render-markdown.nvim",
          dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" },
          ft = { "markdown", "norg", "rmd", "org", "codecompanion" },
          opts = {
            completions = {
              blink = {
                enabled = true
              }
            },
            file_types = { "markdown", "norg", "rmd", "org", "codecompanion" }
          }
        } 
      }   
    }     
  }       
} 
```

However we can use the final value list of `ft` or `cmd` that lazy resolves:

```
    cache = {
      ft_list = { "markdown", "norg", "rmd", "org", "codecompanion", "Avante" }
    },
```

Lazy always resolves `ft` and `cmd` to a list and this `values` function from `lazy.core.plugin` already returns an empty table `{}` when no values are set.

Note: these values are set when `lazy.nvim` loads and resolves them, inside the `values` method it sets the cache if it's not set but it will be set by the time the plugin runs. If this repo don't want to use this method because it sets cache if not set, then I could try to find a way to query `plugin._.cache[key]` directly. Nevertheless I think this PR implementation is safe.
