### PR TITLE
fix: Correct Unicode character alignment for rendered content

### DIFF
--- a/lua/render-markdown/handler/latex.lua
+++ b/lua/render-markdown/handler/latex.lua
@@ -68,7 +68,7 @@ function Handler:expressions(node)
     local lines = str.split(self:convert(node.text), '\n', true)
     local width = vim.fn.max(iter.list.map(lines, str.width))
     for _, line in ipairs(lines) do
-        local prefix = str.pad(node.start_col)
+        local prefix = str.pad(node.display_start_col)
         local suffix = str.pad(width - str.width(line))
         result[#result + 1] = prefix .. line .. suffix
     end

--- a/lua/render-markdown/lib/node.lua
+++ b/lua/render-markdown/lib/node.lua
@@ -18,6 +18,8 @@ local Position = {
 ---@field start_col integer
 ---@field end_row integer
 ---@field end_col integer
+---@field display_start_col integer
+---@field display_end_col integer
 local Node = {}
 Node.__index = Node
 
@@ -30,11 +32,24 @@ function Node.new(buf, node)
     self.node = node
     self.type = node:type()
     self.text = vim.treesitter.get_node_text(node, buf)
-    local start_row, start_col, end_row, end_col = node:range()
+    local start_row, start_col_byte, end_row, end_col_byte = node:range()
+
     self.start_row = start_row
-    self.start_col = start_col
+    self.start_col = start_col_byte
     self.end_row = end_row
-    self.end_col = end_col
+    self.end_col = end_col_byte
+
+    local start_line_text =
+        vim.api.nvim_buf_get_lines(buf, start_row, start_row + 1, false)[1]
+    self.display_start_col = str.width(start_line_text:sub(1, start_col_byte))
+    if start_row == end_row then
+        self.display_end_col = str.width(start_line_text:sub(1, end_col_byte))
+    else
+        local end_lines =
+            vim.api.nvim_buf_get_lines(buf, end_row, end_row + 1, false)
+        local end_line_text = end_lines[1] or ''
+        self.display_end_col = str.width(end_line_text:sub(1, end_col_byte))
+    end
     return self
 end
 


### PR DESCRIPTION
This pull request addresses a visual alignment issue for rendered content,
particularly noticeable with LaTeX formulas and other elements containing
multi-byte Unicode characters. Previously, the rendered output would often
appear horizontally misaligned due to an incorrect conversion between
Treesitter's byte-based column offsets and Neovim's display-based column
widths.

**Problem Addressed:**

The core of the issue was that `TSNode:range()` reports column positions as
byte offsets. When these byte offsets were directly used for padding
(`str.pad`) or passed as `start_col`/`end_col` parameters to
`nvim_buf_set_extmark` (especially with `virt_text_pos='inline'`), it led to
miscalculations for Unicode characters that occupy more bytes than their
display width (e.g., Cyrillic, Chinese).

**Solution Implemented:**

1. **Enhanced `render.md.Node`:** The `Node.new` constructor in `lib/node.lua`
   now calculates and stores two new properties: `display_start_col` and
   `display_end_col`.
   - These properties represent the **actual visual column positions** of the
     node's start and end points.
   - They are computed by measuring the `vim.fn.strdisplaywidth` of the
     substring from the beginning of the line up to the respective byte offset
     reported by `TSNode:range()`.
2. **Consistent Column Usage:** All subsequent operations in
   `handler.buf.latex` (and potentially other handlers that rely on accurate
   column positioning) now consistently use `node.display_start_col` and
   `node.display_end_col` for:
   - Calculating `prefix` and `suffix` padding within `Handler:expressions`.
   - Setting the `start_col` and `end_col` parameters for
     `nvim_buf_set_extmark` calls, especially when `virt_text_pos='inline'`.

**Visual Impact (with Screenshots):**

---

**Before (Current Behavior - with visual misalignment):**

<img width="3840" height="2160" alt="Снимок экрана от 2025-08-21 08-22-37" src="https://github.com/user-attachments/assets/87750e06-507b-4bd2-92a1-b4092a9e518e" />

**After (Desired Behavior - with correct alignment):**

<img width="3840" height="2160" alt="Снимок экрана от 2025-08-21 08-43-57" src="https://github.com/user-attachments/assets/a9cbd9b1-6596-4578-8fac-712180ff576d" />

