### PR TITLE
fix: ctermbg heading borders being all white instead of as configured

### DIFF
--- a/lua/render-markdown/core/colors.lua
+++ b/lua/render-markdown/core/colors.lua
@@ -127,7 +127,10 @@ function M.bg_as_fg(highlight, force)
             fg = hl.bg,
             ctermfg = hl.ctermbg,
         })
-        M.cache.bg_as_fg[name] = { hl = highlight, visible = hl.bg ~= nil }
+        M.cache.bg_as_fg[name] = {
+          hl = highlight,
+          visible = hl.bg ~= nil or hl.ctermbg ~= nil,
+        }
     end
     return M.cache.bg_as_fg[name].visible and name or nil
 end


### PR DESCRIPTION
Hello! I recently updated my neovim from 0.10.x to 0.11.x and updated this plugin, and noticed that my config for headings was using wrong background color for heading borders.

NOTE that I'm still using a cterm-based colorscheme
_(I plan to rewrite it in Lua then in RGB, but it's still not a priority for me at the moment)_

For example:
<img width="316" height="151" alt="image" src="https://github.com/user-attachments/assets/c97ef106-ac91-405e-9046-657db9e5d9ab" />
Where the config looks like:
```lua
...setup {
  heading = {
    foregrounds = { "@markup.heading.1" }
    backgrounds = { "@markup.heading.1.bg" }
  }
```
And those groups are defined as:
```vim
hi @markup.heading.1    ctermfg=196 cterm=bold
hi @markup.heading.1.bg ctermbg=237
```

After this PR it now looks correct:
<img width="318" height="148" alt="image" src="https://github.com/user-attachments/assets/cb93cea0-3293-46b4-9def-b52aea3a1709" />

---
Recent commit introducing the bug: bfd67f1402b97ac619cb538f4bbaed12a7fa89aa