### PR TITLE
feat: add priority to render code background

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ require('render-markdown').setup({
         inline_right = '',
         -- Padding to add to the left & right of inline code.
         inline_pad = 0,
+        -- Priority to assign to highlight for code blocks.
+        priority = nil,
         -- Highlight for code blocks.
         highlight = 'RenderMarkdownCode',
         -- Highlight for code info section, after the language.
@@ -1172,6 +1174,8 @@ require('render-markdown').setup({
         inline_right = '',
         -- Padding to add to the left & right of inline code.
         inline_pad = 0,
+        -- Priority to assign to highlight for code blocks.
+        priority = nil,
         -- Highlight for code blocks.
         highlight = 'RenderMarkdownCode',
         -- Highlight for code info section, after the language.

--- a/doc/render-markdown.txt
+++ b/doc/render-markdown.txt
@@ -573,6 +573,8 @@ Default Configuration ~
             inline_right = '',
             -- Padding to add to the left & right of inline code.
             inline_pad = 0,
+	    -- Priority to assign to highlight for code blocks.
+	    priority = nil,
             -- Highlight for code blocks.
             highlight = 'RenderMarkdownCode',
             -- Highlight for code info section, after the language.
@@ -1232,6 +1234,8 @@ Code Block Configuration ~
             inline_right = '',
             -- Padding to add to the left & right of inline code.
             inline_pad = 0,
+	    -- Priority to assign to highlight for code blocks.
+	    priority = nil,
             -- Highlight for code blocks.
             highlight = 'RenderMarkdownCode',
             -- Highlight for code info section, after the language.

--- a/lua/render-markdown/render/inline/code.lua
+++ b/lua/render-markdown/render/inline/code.lua
@@ -24,6 +24,7 @@ function Render:run()
     local highlight = self.config.highlight_inline
     self.marks:over(self.config, 'code_background', self.node, {
         hl_group = highlight,
+        priority = self.config.priority,
     })
     self:padding(highlight, true)
     self:padding(highlight, false)

--- a/lua/render-markdown/render/markdown/code.lua
+++ b/lua/render-markdown/render/markdown/code.lua
@@ -227,6 +227,7 @@ function Render:background(start_row, end_row)
             end_row = row + 1,
             hl_group = self.config.highlight,
             hl_eol = true,
+            priority = self.config.priority,
         })
         if not padding:empty() and win_col > 0 then
             -- overwrite anything beyond width with padding

--- a/lua/render-markdown/settings.lua
+++ b/lua/render-markdown/settings.lua
@@ -404,6 +404,7 @@ M.code = {}
 ---@field inline_left string
 ---@field inline_right string
 ---@field inline_pad integer
+---@field priority? integer
 ---@field highlight string
 ---@field highlight_info string
 ---@field highlight_language? string
@@ -510,6 +511,8 @@ M.code.default = {
     inline_right = '',
     -- Padding to add to the left & right of inline code.
     inline_pad = 0,
+    -- Priority to assign to highlight for code blocks.
+    priority = nil,
     -- Highlight for code blocks.
     highlight = 'RenderMarkdownCode',
     -- Highlight for code info section, after the language.

--- a/lua/render-markdown/types.lua
+++ b/lua/render-markdown/types.lua
@@ -115,6 +115,7 @@
 ---@field inline_left? string
 ---@field inline_right? string
 ---@field inline_pad? integer
+---@field priority? integer
 ---@field highlight? string
 ---@field highlight_info? string
 ---@field highlight_language? string


### PR DESCRIPTION
This PR adds a priority option for the `code_background` highlight group.

The reason I added this is as that when using `vim.lsp.buf.signature_help`, the `LspSignatureActiveParameter` gets overridden by the `RenderMarkdownCode` which essentially removes that. With this change, you can add a lower priority to the `RenderMarkdownCode` highlight group re-enabling the `LspSignatureActiveParameter`.