### PR TITLE
feat: add more default icons `opts.link.custom`

### DIFF
--- a/lua/render-markdown/settings.lua
+++ b/lua/render-markdown/settings.lua
@@ -1289,6 +1289,7 @@ M.link.default = {
         gitlab = { pattern = 'gitlab%.com', icon = '󰮠 ' },
         google = { pattern = 'google%.com', icon = '󰊭 ' },
         hackernews = { pattern = "ycombinator%.com", icon = " " },
+        linkedin = { pattern = "linkedin%.com", icon = "󰌻 " },
         microsoft = { pattern = "microsoft%.com", icon = " " },
         neovim = { pattern = 'neovim%.io', icon = ' ' },
         reddit = { pattern = 'reddit%.com', icon = '󰑍 ' },


### PR DESCRIPTION
Added some icons for well-known companies that do have their logo available as nerdfont glyph.