### PR TITLE
feat: add more YouTube domains

### DIFF
--- a/lua/render-markdown/settings.lua
+++ b/lua/render-markdown/settings.lua
@@ -1303,6 +1303,8 @@ M.link.default = {
         twitter = { pattern = 'x%.com', icon = ' ' },
         wikipedia = { pattern = 'wikipedia%.org', icon = '󰖬 ' },
         youtube = { pattern = 'youtube%.com', icon = '󰗃 ' },
+        youtube_nocookie = { pattern = 'youtube-nocookie%.com', icon = '󰗃 ' },
+        youtube_short = { pattern = 'youtu%.be', icon = '󰗃 ' },
     },
 }
 


### PR DESCRIPTION
If Lua used regexes it would be simpler to do this (single pattern) but since there's no support for alternation, the current entry is duplicated to support the "youtu.be" and "youtube-nocookie.com" domains.