### PR TITLE
fix: lower priority for code highlights, so `on_yank` and diagnostics are visible

### DIFF
--- a/lua/render-markdown/settings.lua
+++ b/lua/render-markdown/settings.lua
@@ -512,7 +512,7 @@ M.code.default = {
     -- Padding to add to the left & right of inline code.
     inline_pad = 0,
     -- Priority to assign to code background highlight.
-    priority = nil,
+    priority = 140,
     -- Highlight for code blocks.
     highlight = 'RenderMarkdownCode',
     -- Highlight for code info section, after the language.


### PR DESCRIPTION
## Problem
Some user highlights, like for example the one from `vim.hl.on_yank()` (highlighted yank), are not visible when using the inline code highlights:
<img width="365" height="153" alt="Screenshot_2026-01-04_19-18-28" src="https://github.com/user-attachments/assets/dfa04191-3c32-4728-b437-fb8e8fac2001" />

## Solution
While there is an option to define a custom highlight priority, imo it makes sense to have render-markdown have a reasonable default out of the box. Things like highlighted yanks are very common in nvim configs and not depending on a specific LSP or plugin, but built-in nvim features. Having them not play nice with render-markdown's code highlights by default is unfortunate.

I suggest that default priority for code background to be 140. This is since [vim.hl.on_yank](https://neovim.io/doc/user/lua.html#vim.hl.on_yank()) uses [a priority of 200](https://neovim.io/doc/user/lua.html#vim.hl.priorities). Instead of just using 190, I propose 140, since it ensures that the code background also has lower priority than diagnostics [which use 150](https://neovim.io/doc/user/lua.html#vim.hl.priorities).

This results in proper highlighting:

<img width="339" height="124" alt="Screenshot_2026-01-04_19-18-13" src="https://github.com/user-attachments/assets/3245b06c-4c9b-4500-811f-c5c23f6b2fea" />
