### PR TITLE
feat: allow ignoring languages to fix conflicts with image renderers

### DIFF
--- a/lua/render-markdown/render/markdown/code.lua
+++ b/lua/render-markdown/render/markdown/code.lua
@@ -23,6 +23,16 @@ function Render:setup()
     if not self.config.enabled then
         return false
     end
+    -- ignore specific languages
+    local info = self.node:child('info_string')
+    local language = info and info:child('language')
+    if
+        language
+        and self.config.ignore
+        and vim.tbl_contains(self.config.ignore, language.text)
+    then
+        return false
+    end
     -- skip single line code block
     if self.node:height() <= 2 then
         return false

--- a/lua/render-markdown/settings.lua
+++ b/lua/render-markdown/settings.lua
@@ -381,6 +381,7 @@ M.code = {}
 
 ---@class (exact) render.md.code.Config: render.md.base.Config
 ---@field sign boolean
+---@field ignore string[]
 ---@field conceal_delimiters boolean
 ---@field language boolean
 ---@field position render.md.code.Position
@@ -447,6 +448,8 @@ M.code.default = {
     enabled = true,
     -- Additional modes to render code blocks.
     render_modes = false,
+    -- List of languages to ignore rendering for.
+    ignore = {},
     -- Turn on / off sign column related rendering.
     sign = true,
     -- Whether to conceal nodes at the top and bottom of code blocks.
@@ -536,6 +539,7 @@ M.code.default = {
 ---@return render.md.Schema
 function M.code.schema()
     return M.base.schema({
+        ignore = { list = { type = 'string' } },
         sign = { type = 'boolean' },
         conceal_delimiters = { type = 'boolean' },
         language = { type = 'boolean' },

--- a/lua/render-markdown/types.lua
+++ b/lua/render-markdown/types.lua
@@ -92,6 +92,7 @@
 
 ---@class (exact) render.md.code.UserConfig: render.md.base.UserConfig
 ---@field sign? boolean
+---@field ignore? string[]
 ---@field conceal_delimiters? boolean
 ---@field language? boolean
 ---@field position? render.md.code.Position

--- a/tests/ignore_spec.lua
+++ b/tests/ignore_spec.lua
@@ -1,0 +1,34 @@
+local util = require('tests.util')
+
+describe('code ignore', function()
+    it('ignores configured languages', function()
+        util.setup.text({
+            '```mermaid',
+            'graph TD;',
+            '    A-->B;',
+            '```',
+        }, {
+            code = {
+                ignore = { 'mermaid' },
+            },
+        })
+
+        -- Should have no marks
+        util.assert_marks({})
+    end)
+
+    it('ignores nothing by default', function()
+        util.setup.text({
+            '```mermaid',
+            'graph TD;',
+            '    A-->B;',
+            '```',
+        })
+
+        util.assert_screen({
+            'mermaid█████████████████████████████████████████████████████████████████████████',
+            'graph TD;',
+            '    A-->B;',
+        })
+    end)
+end)


### PR DESCRIPTION
I've been monkey-patching this into my config for a while to solve a conflict with snacks.nvim.

When rendering diagrams (like mermaid), render-markdown conceals the code block ticks and applies its own styling, which prevents snacks from correctly detecting and rendering the diagram image.

This PR adds an ignore list to the code config (e.g., ignore = { "mermaid" }). If a language is in this list, the plugin will skip rendering it entirely, allowing other tools to handle it without interference.

Please let me know if you think this is a good addition or if there's a better way to handle these conflicts