### PR TITLE
fix: Don't prevent rendering if buffer is empty

### DIFF
--- a/lua/render-markdown/core/ui.lua
+++ b/lua/render-markdown/core/ui.lua
@@ -71,9 +71,6 @@ function Updater:start()
     if not env.valid(self.buf, self.win) then
         return
     end
-    if env.buf.empty(self.buf) then
-        return
-    end
     self.decorator:schedule(
         self:changed(),
         self.config.debounce,


### PR DESCRIPTION
I think this: https://github.com/sudo-tee/opencode.nvim/issues/200

Is actually a bug with this plugin.

If the text is non-empty, then is changed to empty via `vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})`, `render-markdown.nvim` should still render in that case, otherwise it leaves behind some extmarks (I think those are extmarks)?