### PR TITLE
fix: always use image icon for image links, regardless of URL type

### DIFF
--- a/lua/render-markdown/render/inline/link.lua
+++ b/lua/render-markdown/render/inline/link.lua
@@ -28,11 +28,11 @@ function Render:setup()
         icon[1] = self.config.email
         autolink = true
     elseif self.node.type == 'image' then
-        icon[1] = self.config.image
         local destination = self.node:child('link_destination')
         if destination then
             self.context.config:set_link_text(destination.text, icon)
         end
+        icon[1] = self.config.image
         title = self.node:child('link_title')
     elseif self.node.type == 'inline_link' then
         local destination = self.node:child('link_destination')


### PR DESCRIPTION
This PR fixes an issue where image links (`![alt](...)`) do not consistently display the image icon.

Currently, the plugin assigns icons based on the link target:

- Local image paths correctly use the image icon
- Image links pointing to web URLs (e.g. https://...) are treated as normal web links and get the web URL icon instead

I personally think that image links should always display the image icon, regardless of the URL type.