### PR TITLE
feat(checkbox): add built-in 'bug' custom checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ require('render-markdown').setup({
         -- stylua: ignore
         custom = {
             todo = { raw = '[-]', rendered = '󰥔 ', highlight = 'RenderMarkdownTodo', scope_highlight = nil },
+            bug  = { raw = '[b]', rendered = '󰃤 ', highlight = 'RenderMarkdownBug',  scope_highlight = nil },
         },
         -- Priority to assign to scope highlight.
         scope_priority = nil,
@@ -1383,6 +1384,7 @@ require('render-markdown').setup({
         -- stylua: ignore
         custom = {
             todo = { raw = '[-]', rendered = '󰥔 ', highlight = 'RenderMarkdownTodo', scope_highlight = nil },
+            bug  = { raw = '[b]', rendered = '󰃤 ', highlight = 'RenderMarkdownBug',  scope_highlight = nil },
         },
         -- Priority to assign to scope highlight.
         scope_priority = nil,
@@ -1754,6 +1756,7 @@ The table below shows all the highlight groups with their default link
 | RenderMarkdownUnchecked       | @markup.list.unchecked             | Unchecked checkbox         |
 | RenderMarkdownChecked         | @markup.list.checked               | Checked checkbox           |
 | RenderMarkdownTodo            | @markup.raw                        | Todo custom checkbox       |
+| RenderMarkdownBug             | DiagnosticError                    | Bug custom checkbox        |
 | RenderMarkdownTableHead       | @markup.heading                    | Pipe table heading rows    |
 | RenderMarkdownTableRow        | Normal                             | Pipe table body rows       |
 | RenderMarkdownTableFill       | Conceal                            | Pipe table inline padding  |

--- a/doc/render-markdown.txt
+++ b/doc/render-markdown.txt
@@ -717,6 +717,7 @@ Default Configuration ~
             -- stylua: ignore
             custom = {
                 todo = { raw = '[-]', rendered = '󰥔 ', highlight = 'RenderMarkdownTodo', scope_highlight = nil },
+                bug  = { raw = '[b]', rendered = '󰃤 ', highlight = 'RenderMarkdownBug',  scope_highlight = nil },
             },
             -- Priority to assign to scope highlight.
             scope_priority = nil,
@@ -1437,6 +1438,7 @@ Checkbox Configuration ~
             -- stylua: ignore
             custom = {
                 todo = { raw = '[-]', rendered = '󰥔 ', highlight = 'RenderMarkdownTodo', scope_highlight = nil },
+                bug  = { raw = '[b]', rendered = '󰃤 ', highlight = 'RenderMarkdownBug',  scope_highlight = nil },
             },
             -- Priority to assign to scope highlight.
             scope_priority = nil,
@@ -1849,6 +1851,8 @@ The table below shows all the highlight groups with their default link
   RenderMarkdownChecked           @markup.list.checked                 Checked checkbox
 
   RenderMarkdownTodo              @markup.raw                          Todo custom checkbox
+
+  RenderMarkdownBug               DiagnosticError                      Bug custom checkbox
 
   RenderMarkdownTableHead         @markup.heading                      Pipe table heading
                                                                        rows

--- a/lua/render-markdown/core/colors.lua
+++ b/lua/render-markdown/core/colors.lua
@@ -53,6 +53,7 @@ M.colors = {
     Unchecked       = '@markup.list.unchecked',
     Checked         = '@markup.list.checked',
     Todo            = '@markup.raw',
+    Bug             = 'DiagnosticError',
     -- Pipe tables
     TableHead       = '@markup.heading',
     TableRow        = 'Normal',

--- a/lua/render-markdown/settings.lua
+++ b/lua/render-markdown/settings.lua
@@ -341,6 +341,7 @@ M.checkbox.default = {
     -- stylua: ignore
     custom = {
         todo = { raw = '[-]', rendered = '󰥔 ', highlight = 'RenderMarkdownTodo', scope_highlight = nil },
+        bug  = { raw = '[b]', rendered = '󰃤 ', highlight = 'RenderMarkdownBug',  scope_highlight = nil },
     },
     -- Priority to assign to scope highlight.
     scope_priority = nil,


### PR DESCRIPTION
## Summary

- Adds a new built-in custom checkbox `[b]` that renders as `󰃤` (nf-md-bug) for tracking bugs in markdown task lists
- Adds `RenderMarkdownBug` highlight group linked to `DiagnosticError` (red) by default
- Updates README and vimdoc with the new checkbox and highlight entry

## Motivation

Bug tracking is a common use case in markdown task lists. Currently, users must manually configure a custom checkbox for this. Adding `[b]` as a built-in (alongside the existing `[-]` for todo) provides a convenient out-of-the-box experience:

```markdown
- [b] Login page crashes on submit
- [b] Null pointer in auth module
- [-] Refactor auth module
- [x] Add unit tests
```

The `DiagnosticError` highlight (red) visually distinguishes bugs from regular tasks, matching the convention most developers expect for bug indicators.

## Changes

| File | Change |
|------|--------|
| `lua/render-markdown/settings.lua` | Add `bug` entry to `custom` checkbox defaults |
| `lua/render-markdown/core/colors.lua` | Add `Bug = 'DiagnosticError'` highlight mapping |
| `README.md` | Document new checkbox and highlight group |
| `doc/render-markdown.txt` | Document new checkbox and highlight group |

## Test plan

- [ ] Verify `- [b]` renders as `󰃤` with red highlight in a markdown buffer
- [ ] Verify existing `- [-]` todo checkbox still works as before
- [ ] Verify `RenderMarkdownBug` highlight group defaults to `DiagnosticError`
- [ ] Verify users can override `bug` in their config like any other custom checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)