### PR TITLE
fix: harden render against stale window and node inputs

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ bench:
 
 [private]
 busted path:
-  nvim --headless --noplugin -u {{init}} -c "PlenaryBustedDirectory {{path}} {{settings}}"
+  nvim --headless --clean -u {{init}} -c "PlenaryBustedDirectory {{path}} {{settings}}"
 
 health:
   nvim -c "checkhealth render-markdown" -- -

--- a/lua/render-markdown/lib/env.lua
+++ b/lua/render-markdown/lib/env.lua
@@ -207,6 +207,12 @@ function M.buf.wins(buf)
     return vim.fn.win_findbuf(buf)
 end
 
+---@param buf integer
+---@return integer[]
+function M.buf.windows(buf)
+    return M.buf.wins(buf)
+end
+
 ---@class render.md.env.Win
 M.win = {}
 

--- a/lua/render-markdown/render/base.lua
+++ b/lua/render-markdown/render/base.lua
@@ -13,6 +13,15 @@ Base.__index = Base
 ---@param node render.md.Node
 ---@return boolean
 function Base:execute(context, marks, node)
+    if type(node) ~= 'table' or type(node.height) ~= 'function' then
+        local Node = require('render-markdown.lib.node')
+        local ok, wrapped = pcall(Node.new, context.buf, node)
+        if not ok or not wrapped then
+            return false
+        end
+        node = wrapped
+    end
+
     local instance = setmetatable({}, self)
     instance.context = context
     instance.marks = marks

--- a/lua/render-markdown/request/view.lua
+++ b/lua/render-markdown/request/view.lua
@@ -14,9 +14,14 @@ View.__index = View
 function View.new(buf)
     local self = setmetatable({}, View)
     self.buf = buf
+    local wins = env.buf.wins and env.buf.wins(buf)
+        or (env.buf.windows and env.buf.windows(buf))
+        or {}
     local ranges = {} ---@type render.md.Range[]
-    for _, win in ipairs(env.buf.wins(buf)) do
-        ranges[#ranges + 1] = env.range(buf, win, 10)
+    for _, win in ipairs(wins) do
+        if not env.valid or env.valid(buf, win) then
+            ranges[#ranges + 1] = env.range(buf, win, 10)
+        end
     end
     self.ranges = interval.coalesce(ranges)
     return self
@@ -34,6 +39,9 @@ end
 ---@param win integer
 ---@return boolean
 function View:contains(win)
+    if env.valid and not env.valid(self.buf, win) then
+        return false
+    end
     local rows = env.range(self.buf, win, 0)
     for _, range in ipairs(self.ranges) do
         if interval.contains(range, rows) then

--- a/tests/unit/base_spec.lua
+++ b/tests/unit/base_spec.lua
@@ -1,0 +1,32 @@
+---@module 'luassert'
+
+local Base = require('render-markdown.render.base')
+local mock = require('luassert.mock')
+
+describe('base', function()
+    it('normalizes raw nodes before setup', function()
+        local Node = mock(require('render-markdown.lib.node'), true)
+        local wrapped = {
+            height = function()
+                return 3
+            end,
+        }
+        Node.new.on_call_with(1, 'raw-node').returns(wrapped)
+
+        local ran = false
+        local Render = setmetatable({}, Base)
+        Render.__index = Render
+
+        function Render:setup()
+            return type(self.node.height) == 'function'
+        end
+
+        function Render:run()
+            ran = true
+        end
+
+        local ok = Render:execute({ buf = 1 }, {}, 'raw-node')
+        assert.is_true(ok)
+        assert.is_true(ran)
+    end)
+end)

--- a/tests/unit/view_spec.lua
+++ b/tests/unit/view_spec.lua
@@ -9,6 +9,7 @@ describe('view', function()
         local env = mock(require('render-markdown.lib.env'), true)
         env.buf.wins.on_call_with(0).returns(vim.tbl_keys(ranges))
         for win, range in pairs(ranges) do
+            env.valid.on_call_with(0, win).returns(true)
             env.range.on_call_with(0, win, 10).returns(range)
         end
     end
@@ -21,5 +22,14 @@ describe('view', function()
             [1003] = { 35, 45 },
         })
         assert.same('[0->15,20->30,35->45]', tostring(View.new(0)))
+    end)
+
+    it('contains invalid window', function()
+        local env = mock(require('render-markdown.lib.env'), true)
+        env.buf.wins.on_call_with(0).returns({ 1000 })
+        env.valid.on_call_with(0, 1000).returns(true)
+        env.range.on_call_with(0, 1000, 10).returns({ 5, 10 })
+        env.valid.on_call_with(0, 1001).returns(false)
+        assert.is_false(View.new(0):contains(1001))
     end)
 end)


### PR DESCRIPTION
Add compatibility fallbacks and defensive guards so mixed plugin states or transient windows do not crash scheduled renders, and keep tests runnable on Neovim builds that use --clean instead of --noplugin.


Hi,

I am using https://github.com/sudo-tee/opencode.nvim and had often several errors with the plugin because of prop access of non existing objects. And seldom on larger md files.
Now everything runs smoothly.

Best regards
