### PR TITLE
feat: show cursorline in full width code blocks

### DIFF
--- a/lua/render-markdown/render/markdown/code.lua
+++ b/lua/render-markdown/render/markdown/code.lua
@@ -239,7 +239,10 @@ function Render:background(start_row, end_row)
     end
     local col = self.node.start_col
     for row = start_row, end_row do
-        self.marks:add(self.config, 'code_background', row, col, {
+        -- Allow cursorline to work when using full width backgrounds
+        local conceal = self.config.width == 'full' and true
+            or 'code_background'
+        self.marks:add(self.config, conceal, row, col, {
             end_row = row + 1,
             priority = self.config.priority,
             hl_group = self.config.highlight,


### PR DESCRIPTION
This small code change makes cursorline show up in code blocks.

I'm new at nvim lua, and I don't understand the code at all. I was trying to read the code and see if I could make this work and a little hit-and-trial got me here. I was curious how the cursorline worked on the language line but not on the code lines, and wanted to see if I could replicate the same behaviour for code lines as well.

I'm honestly not sure if this breaks anything else. Please let me know if this is a good idea and I can update the PR to fix docs/screenshots etc.

In my limited testing with the following config it's working well:

```lua
{
  "MeanderingProgrammer/render-markdown.nvim",
  opts = {
    code = {
      sign = false, -- from LazyVim
      width = "full",
      border = "thick",
      right_pad = 1, -- from LazyVim
    },
  },
}
```

<img width="1728" height="1046" alt="image" src="https://github.com/user-attachments/assets/a95686dd-7a12-4945-9a61-36b6414edd02" />