### PR TITLE
fix: heading padding column offset inside block quotes

### DIFF
--- a/lua/render-markdown/render/markdown/heading.lua
+++ b/lua/render-markdown/render/markdown/heading.lua
@@ -252,8 +252,9 @@ function Render:padding(box)
     if line:empty() then
         return
     end
+    local start_col = self.node.start_col
     for row = self.node.start_row, self.node.end_row - 1 do
-        self.marks:add(self.config, false, row, 0, {
+        self.marks:add(self.config, false, row, start_col, {
             priority = 100,
             virt_text = line:get(),
             virt_text_pos = 'inline',


### PR DESCRIPTION
After the fix for nested headings inside block quotes, heading padding virtual text was still rendered at column 0 regardless of nesting depth. This caused the padding to overlap with the block quote marker rather than aligning with the headign content.

 Without this fix, the concrete problem is:
 When you have a heading nested inside a block quote like:

```markdown
  > # Hello
```