### PR TITLE
fix: conceal padding spaces in multi-backtick code spans per CommonMark spec

### DIFF
--- a/lua/render-markdown/render/inline/code.lua
+++ b/lua/render-markdown/render/inline/code.lua
@@ -23,8 +23,50 @@ function Render:run()
         priority = self.config.priority,
         hl_group = highlight,
     })
+    self:conceal_padding()
     self:padding(highlight, true)
     self:padding(highlight, false)
+end
+
+--- Per CommonMark spec, when a code span uses multiple backtick delimiters,
+--- a single leading and trailing space is stripped from the content (provided
+--- the content is not entirely whitespace). Conceal those spaces so the
+--- rendered output matches what CommonMark produces.
+---@private
+function Render:conceal_padding()
+    local delimiters = {}
+    self.node:for_each_child(function(child)
+        if child.type == 'code_span_delimiter' then
+            delimiters[#delimiters + 1] = child
+        end
+    end)
+    if #delimiters < 2 then
+        return
+    end
+    -- Only applies when delimiter is more than one backtick
+    local open = delimiters[1]
+    local close = delimiters[#delimiters]
+    if (open.end_col - open.start_col) <= 1 then
+        return
+    end
+    -- Extract the text between delimiters
+    local content = self.node.text:sub(open.end_col - self.node.start_col + 1, close.start_col - self.node.start_col)
+    -- Content must start and end with a space and not be entirely whitespace
+    if not (content:sub(1, 1) == ' ' and content:sub(-1) == ' ' and content:match('%S')) then
+        return
+    end
+    -- Conceal the leading space (right after opening delimiter)
+    self.marks:add(self.config, true, open.end_row, open.end_col, {
+        end_row = open.end_row,
+        end_col = open.end_col + 1,
+        conceal = '',
+    })
+    -- Conceal the trailing space (right before closing delimiter)
+    self.marks:add(self.config, true, close.start_row, close.start_col - 1, {
+        end_row = close.start_row,
+        end_col = close.start_col,
+        conceal = '',
+    })
 end
 
 ---@private


### PR DESCRIPTION
CommonMark specifies that when a code span uses multiple backtick delimiters, a single leading and trailing space is stripped from the content, provided the content is not entirely whitespace. This is the standard way to include literal backticks in inline code.

For example, to render Cmd+` as inline code, one writes:

    `` Cmd+` ``

The double backticks are delimiters, and the spaces adjacent to them are padding that should not appear in the rendered output.

Previously, render-markdown.nvim correctly concealed the backtick delimiters but left the padding spaces visible, resulting in extra whitespace in the rendered output.

This adds a conceal_padding step to the inline code renderer that detects multi-backtick code spans and conceals the inner padding spaces, matching the expected CommonMark rendering.

Reference: https://spec.commonmark.org/0.31.2/#code-spans (examples 349-362)