### PR TITLE
test: isolate tests from user config

### DIFF
--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -12,6 +12,10 @@ vim.o.lines = 40
 vim.o.tabstop = 4
 vim.o.wrap = false
 
+-- isolate tests from user ftplugins
+vim.opt.rtp:remove(vim.fn.stdpath('config'))
+vim.opt.rtp:remove(vim.fn.stdpath('config') .. '/after')
+
 -- source dependencies first
 vim.opt.rtp:prepend(get_path('nvim-treesitter'))
 vim.cmd.runtime('plugin/nvim-treesitter.lua')


### PR DESCRIPTION
Some of the tests were failing on my machine because I have `vim.opt_local.tabstop = 2` in my `after/ftplugin/markdown.lua`. Removing `config` and `config/after` from the runtime path during the test init makes sure the personal config isn't affecting tests.